### PR TITLE
Update emoji and increase profile image size

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>BoomBigNose 💼</title>
+    <title>BoomBigNose 👃</title>
     <meta name="description" content="AI-first full-stack engineer building production-ready intelligent solutions. 4+ years experience in healthcare, education, and consumer AI applications.">
     <meta name="keywords" content="AI Engineer, Full-Stack Developer, Machine Learning, Mobile Development, TypeScript, Python, React">
     <meta name="author" content="Vittawat Sootawee">
@@ -15,7 +15,7 @@
     <meta property="og:image" content="assets/profile.jpg">
     
     <!-- Favicon -->
-    <link rel="icon" type="image/x-icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>💼</text></svg>">
+    <link rel="icon" type="image/x-icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>👃</text></svg>">
     
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -352,8 +352,8 @@
         
         /* Profile Image */
         .hero-profile {
-            width: 200px;
-            height: 200px;
+            width: 300px;
+            height: 300px;
             border-radius: 50%;
             margin: 0 auto var(--space-xl);
             border: 4px solid var(--accent-electric);


### PR DESCRIPTION
This commit addresses your feedback to:
- Change the favicon and website title emoji to the nose emoji (👃).
- Increase the profile image size in the hero section to 300px by 300px.

CSS for `.hero-profile` was updated, and relevant tags in `index.html` were modified for the emoji change.